### PR TITLE
Filter field no longer expects "expr" key

### DIFF
--- a/src/vega_lite.ml
+++ b/src/vega_lite.ml
@@ -290,7 +290,7 @@ module Transform = struct
   let aggregate1 ?(opts=[]) op : t =
     ["aggregate", Aggregate.to_json op] @ opts
 
-  let filter ?(opts=[]) ~expr () = ["filter", `Assoc ["expr", `String expr]] @ opts
+  let filter ?(opts=[]) ~expr () = ["filter", `String expr] @ opts
   let sample ?(opts=[]) ~max () = ["sample", `Assoc ["sample", `Int max]] @ opts
 
   let other j : t = j


### PR DESCRIPTION
Hi @c-cube ,

Thank you for writing this library! It's really useful for what I am working on. Are there any plans to release it? I would be happy to contribute to it as I try to this library more. This PR has just one tweak. The filter function no longer expects "expr" field as per the v5 schema: https://vega.github.io/vega-lite/docs/filter.html